### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/dummy/log/*.log
 test/dummy/db/*.sqlite3
 test/dummy/db/*.sqlite3-journal
 node_modules/
+.rubocop-http*

--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,7 @@ $(cat CHANGELOG.md)" > CHANGELOG.md'
   system 'git add CHANGELOG.md && git commit -m "Update changelog" && git push origin HEAD'
 
   system "git tag -a v#{Workarea::SliderBlock::VERSION} -m 'Tagging #{Workarea::SliderBlock::VERSION}'"
-  system 'git push --tags'
+  system 'git push origin HEAD --follow-tags'
 
   system 'gem build workarea-slider_block.gemspec'
   system "gem push workarea-slider_block-#{Workarea::SliderBlock::VERSION}.gem --host #{host}"

--- a/Rakefile
+++ b/Rakefile
@@ -16,8 +16,9 @@ end
 APP_RAKEFILE = File.expand_path('../test/dummy/Rakefile', __FILE__)
 load 'rails/tasks/engine.rake'
 load 'rails/tasks/statistics.rake'
-
+load 'workarea/changelog.rake'
 require 'rake/testtask'
+
 Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
@@ -29,64 +30,13 @@ task default: :test
 $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'workarea/slider_block/version'
 
-desc 'Generate the changelog based on git history'
-task :changelog, :from, :to do |t, args|
-  require 'date'
-
-  from = args[:from] || `git describe --tags --abbrev=0`.strip
-  to = args[:to] || 'HEAD'
-  log = `git log #{from}..#{to} --pretty=format:'%an|%B___'`
-
-  puts "Workarea Slider Block #{Workarea::SliderBlock::VERSION} (#{Date.today})"
-  puts '-' * 80
-  puts
-
-  log.split(/___/).each do |commit|
-    pieces = commit.split('|').reverse
-    author = pieces.pop.strip
-    message = pieces.join.strip
-
-    next if message =~ /^\s*Merge pull request/
-    next if message =~ /No changelog/i
-
-    project_key = 'SLIDEBLOCK'
-
-    if project_key.blank?
-      puts "To clean up your release notes, add your project's Jira key to the Changelog Rake task!"
-    else
-      ticket = message.scan(/#{project_key}-\d+/)[0]
-      next if ticket.nil?
-      next if message =~ /^\s*Merge branch/ && ticket.nil?
-    end
-
-    first_line = false
-
-    message.each_line do |line|
-      if !first_line
-        first_line = true
-        puts "*   #{line}"
-      elsif line.strip.empty?
-        puts
-      else
-        puts "    #{line}"
-      end
-    end
-
-    puts "    #{author}"
-    puts
-  end
-end
-
 desc "Release version #{Workarea::SliderBlock::VERSION} of the gem"
 task :release do
   host = "https://#{ENV['BUNDLE_GEMS__WEBLINC__COM']}@gems.weblinc.com"
 
-  system 'touch CHANGELOG.md'
-  system 'echo "$(rake changelog)
-
-
-$(cat CHANGELOG.md)" > CHANGELOG.md'
-  system 'git add CHANGELOG.md && git commit -m "Update changelog" && git push origin HEAD'
+  Rake::Task['workarea:changelog'].execute
+  system 'git add CHANGELOG.md'
+  system 'git commit -m "Update CHANGELOG"'
 
   system "git tag -a v#{Workarea::SliderBlock::VERSION} -m 'Tagging #{Workarea::SliderBlock::VERSION}'"
   system 'git push origin HEAD --follow-tags'


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

No changelog

WORKAREA-148